### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Syntax-Perfect supports the following data types:
 
 - `int`: Integer type
 - `pint`: Positive Integer type, an integer that can not be less than 0
-- `float`: String type
+- `float`: Floating point type
 - `bool`: Boolean type
 - `char`: Character type
 - `str`: String type


### PR DESCRIPTION
`float` is probably not a String type? :) Some other wording might be preferred, but this points out the issue at least!